### PR TITLE
Add PF-specific investment fields and PF retirement projection (8.25%) in AI Insights

### DIFF
--- a/backend/src/main/java/com/fintrack/controller/InvestmentController.java
+++ b/backend/src/main/java/com/fintrack/controller/InvestmentController.java
@@ -65,6 +65,9 @@ public class InvestmentController {
                     if (investment.getShares() != null) existingInvestment.setShares(investment.getShares());
                     if (investment.getAvgCost() != null) existingInvestment.setAvgCost(investment.getAvgCost());
                     if (investment.getCurrentValue() != null) existingInvestment.setCurrentValue(investment.getCurrentValue());
+                    if (investment.getPfCurrentCompany() != null) existingInvestment.setPfCurrentCompany(investment.getPfCurrentCompany());
+                    if (investment.getPfPreviousCompany() != null) existingInvestment.setPfPreviousCompany(investment.getPfPreviousCompany());
+                    if (investment.getPfCurrentAge() != null) existingInvestment.setPfCurrentAge(investment.getPfCurrentAge());
                     return ResponseEntity.ok(investmentRepository.save(existingInvestment));
                 })
                 .orElse(ResponseEntity.notFound().build());

--- a/backend/src/main/java/com/fintrack/model/Investment.java
+++ b/backend/src/main/java/com/fintrack/model/Investment.java
@@ -28,4 +28,13 @@ public class Investment {
     private String avgCost;
     @Column(name = "current_value")
     private String currentValue;
+
+    @Column(name = "pf_current_company")
+    private String pfCurrentCompany;
+
+    @Column(name = "pf_previous_company")
+    private String pfPreviousCompany;
+
+    @Column(name = "pf_current_age")
+    private String pfCurrentAge;
 }

--- a/client/src/pages/ai-insights.tsx
+++ b/client/src/pages/ai-insights.tsx
@@ -155,6 +155,42 @@ export default function AIInsightsPage() {
             </CardContent>
           </Card>
 
+
+          <Card className="mb-8">
+            <CardHeader>
+              <CardTitle className="flex items-center">
+                <Target className="mr-2 h-5 w-5" />
+                PF Retirement Projection
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {savingsData?.pfPrincipal > 0 ? (
+                <div className="space-y-4">
+                  <p className="text-sm text-muted-foreground">
+                    Based on your current PF + company contributions and fixed PF interest rate of {savingsData?.pfInterestRate || 8.25}%.
+                  </p>
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                    {[50, 55, 60].map((age) => (
+                      <div key={age} className="rounded-lg border p-4 bg-muted/30">
+                        <p className="text-sm text-muted-foreground">At age {age}</p>
+                        <p className="text-lg font-semibold text-foreground">
+                          {formatCurrency(savingsData?.pfRetirementProjection?.[`age${age}`] || 0)}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="text-sm text-muted-foreground space-y-1">
+                    <p>Current PF: {formatCurrency(savingsData?.pfPrincipal || 0)}</p>
+                    <p>Current company PF amount: {formatCurrency(savingsData?.pfCurrentCompanyTotal || 0)}</p>
+                    <p>Previous company PF amount: {formatCurrency(savingsData?.pfPreviousCompanyTotal || 0)}</p>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-muted-foreground">Add a PF investment with current and previous company details to view retirement projection for ages 50-60.</p>
+              )}
+            </CardContent>
+          </Card>
+
           {/* Investment Recommendations */}
           <Card>
             <CardHeader>


### PR DESCRIPTION
### Motivation
- Users need PF investments to capture company-specific PF details (current/previous company amounts and current age) and see a retirement corpus projection at ages 50/55/60 using the fixed PF interest rate 8.25%.

### Description
- Added PF-specific fields to the Investment model: `pfCurrentCompany`, `pfPreviousCompany`, and `pfCurrentAge` and preserved existing fields for compatibility (`backend/src/main/java/com/fintrack/model/Investment.java`).
- Persist PF fields during investment updates by saving `pfCurrentCompany`, `pfPreviousCompany`, and `pfCurrentAge` in the investment update API (`backend/src/main/java/com/fintrack/controller/InvestmentController.java`).
- Extended the savings-projection endpoint to aggregate PF investments (current PF + current-company + previous-company), infer current age when available, compute retirement projections for ages 50/55/60 using a fixed 8.25% interest, and return these values for the UI (`backend/src/main/java/com/fintrack/controller/InsightsController.java`).
- Updated Add/Edit Investment modals to show PF-specific inputs when `type === 'pf'` (placeholders, required `pfCurrentAge` validation via Zod, mapping of PF fields into payloads) and to map existing fields into `pfCurrentCompany`/`pfPreviousCompany` for compatibility (`client/src/components/modals/add-investment-modal.tsx`, `client/src/components/modals/edit-investment-modal.tsx`).
- Added a PF Retirement Projection card to the AI Insights page to display projected PF corpus at ages 50/55/60 and current PF/company totals (`client/src/pages/ai-insights.tsx`).

### Testing
- `npm run build` (frontend build) — succeeded (Vite build completed).
- `mvn -q test` (backend tests) — failed in this environment due to Maven Central access error (403) resolving parent POM, not due to unit failures in code changes.
- `npm run check` (TypeScript compile) — failed due to pre-existing TypeScript typing issues in unrelated files; PF changes did not introduce new global typing failures.
- Dev server started and a Playwright script was run to open the app and capture the Add Investment modal UI, producing a screenshot for visual verification (artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698621aa9c748333886cc4302f356dac)