### PR TITLE
Fix malformed Add/Edit investment modal code (remove duplicates & restore payload)

### DIFF
--- a/client/src/components/modals/add-investment-modal.tsx
+++ b/client/src/components/modals/add-investment-modal.tsx
@@ -33,18 +33,6 @@ const investmentSchema = z.object({
     if (!data.pfCompanyAmount) {
       ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["pfCompanyAmount"], message: "Company PF amount is required" });
     }
-  shares: z.string().min(1, "Value is required"),
-  avgCost: z.string().min(1, "Value is required"),
-  currentValue: z.string().min(1, "Current value is required"),
-  purchaseDate: z.string().min(1, "Purchase date is required"),
-  pfCurrentAge: z.string().optional(),
-}).superRefine((data, ctx) => {
-  if (data.type === "pf" && !data.pfCurrentAge) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ["pfCurrentAge"],
-      message: "Current age is required for PF projection",
-    });
   }
 });
 
@@ -86,10 +74,6 @@ export default function AddInvestmentModal({ isOpen, onClose }: AddInvestmentMod
         avgCost: data.type === "pf" ? "0" : data.avgCost,
         pfCurrentCompany: data.type === "pf" ? (isCurrentCompany ? data.pfCompanyAmount : "0") : null,
         pfPreviousCompany: data.type === "pf" ? (isCurrentCompany ? "0" : data.pfCompanyAmount) : null,
-      const payload = {
-        ...data,
-        pfCurrentCompany: data.type === "pf" ? data.avgCost : null,
-        pfPreviousCompany: data.type === "pf" ? data.shares : null,
       };
       return apiRequest("POST", "/api/investments", payload);
     },
@@ -103,11 +87,6 @@ export default function AddInvestmentModal({ isOpen, onClose }: AddInvestmentMod
     },
     onError: (error) => {
       toast({ title: "Error", description: `Failed to add investment: ${error.message}`, variant: "destructive" });
-      toast({
-        title: "Error",
-        description: `Failed to add investment: ${error.message}`,
-        variant: "destructive"
-      });
     }
   });
 
@@ -136,24 +115,12 @@ export default function AddInvestmentModal({ isOpen, onClose }: AddInvestmentMod
           <div>
             <Label htmlFor="symbol">Symbol</Label>
             <Input id="symbol" placeholder={isPfInvestment ? "e.g., UAN" : "e.g., AAPL, NIFTYBEES"} {...register("symbol")} className={errors.symbol ? "border-red-500" : ""} />
-            <Input
-              id="symbol"
-              placeholder={isPfInvestment ? "e.g., UAN" : "e.g., AAPL, GOOGL"}
-              {...register("symbol")}
-              className={errors.symbol ? "border-red-500" : ""}
-            />
             {errors.symbol && <p className="text-sm text-red-500 mt-1">{errors.symbol.message}</p>}
           </div>
 
           <div>
             <Label htmlFor="name">Investment Name</Label>
             <Input id="name" placeholder={isPfInvestment ? "e.g., Employee Provident Fund" : "e.g., Apple Inc."} {...register("name")} className={errors.name ? "border-red-500" : ""} />
-            <Input
-              id="name"
-              placeholder={isPfInvestment ? "e.g., Employee Provident Fund" : "e.g., Apple Inc."}
-              {...register("name")}
-              className={errors.name ? "border-red-500" : ""}
-            />
             {errors.name && <p className="text-sm text-red-500 mt-1">{errors.name.message}</p>}
           </div>
 
@@ -225,66 +192,6 @@ export default function AddInvestmentModal({ isOpen, onClose }: AddInvestmentMod
               </div>
             </>
           )}
-          <div>
-            <Label htmlFor="shares">{isPfInvestment ? "Previous Company PF Amount" : "Number of Shares"}</Label>
-            <Input
-              id="shares"
-              type="number"
-              step="0.01"
-              placeholder="0.00"
-              {...register("shares")}
-              className={errors.shares ? "border-red-500" : ""}
-            />
-            {errors.shares && <p className="text-sm text-red-500 mt-1">{errors.shares.message}</p>}
-          </div>
-
-          <div>
-            <Label htmlFor="avgCost">{isPfInvestment ? "Current Company PF Amount" : "Average Cost per Share"}</Label>
-            <div className="relative">
-              <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">{getCurrencySymbol()}</span>
-              <Input
-                id="avgCost"
-                type="number"
-                step="0.01"
-                placeholder="0.00"
-                className={`pl-8 ${errors.avgCost ? "border-red-500" : ""}`}
-                {...register("avgCost")}
-              />
-            </div>
-            {errors.avgCost && <p className="text-sm text-red-500 mt-1">{errors.avgCost.message}</p>}
-          </div>
-
-          <div>
-            <Label htmlFor="currentValue">{isPfInvestment ? "Current PF Balance" : "Current Value"}</Label>
-            <div className="relative">
-              <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">{getCurrencySymbol()}</span>
-              <Input
-                id="currentValue"
-                type="number"
-                step="0.01"
-                placeholder="0.00"
-                className={`pl-8 ${errors.currentValue ? "border-red-500" : ""}`}
-                {...register("currentValue")}
-              />
-            </div>
-            {errors.currentValue && <p className="text-sm text-red-500 mt-1">{errors.currentValue.message}</p>}
-          </div>
-
-          {isPfInvestment && (
-            <div>
-              <Label htmlFor="pfCurrentAge">Current Age</Label>
-              <Input
-                id="pfCurrentAge"
-                type="number"
-                min="18"
-                max="60"
-                placeholder="e.g., 32"
-                {...register("pfCurrentAge")}
-                className={errors.pfCurrentAge ? "border-red-500" : ""}
-              />
-              {errors.pfCurrentAge && <p className="text-sm text-red-500 mt-1">{errors.pfCurrentAge.message}</p>}
-            </div>
-          )}
 
           <div>
             <Label htmlFor="purchaseDate">Purchase Date</Label>
@@ -295,14 +202,6 @@ export default function AddInvestmentModal({ isOpen, onClose }: AddInvestmentMod
           <div className="flex justify-end space-x-2 pt-4">
             <Button type="button" variant="outline" onClick={onClose}>Cancel</Button>
             <Button type="submit" disabled={addInvestmentMutation.isPending} className="bg-finance-blue hover:bg-blue-700">
-            <Button type="button" variant="outline" onClick={onClose}>
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              disabled={addInvestmentMutation.isPending}
-              className="bg-finance-blue hover:bg-blue-700"
-            >
               {addInvestmentMutation.isPending ? "Adding..." : "Add Investment"}
             </Button>
           </div>

--- a/client/src/components/modals/edit-investment-modal.tsx
+++ b/client/src/components/modals/edit-investment-modal.tsx
@@ -26,8 +26,6 @@ export default function EditInvestmentModal({ isOpen, onClose, investment }: Edi
     pfCurrentAge: "",
     pfCompanyType: "current",
     pfCompanyAmount: "",
-    pfCurrentCompany: "",
-    pfPreviousCompany: "",
   });
 
   const { getCurrencySymbol } = useCurrency();
@@ -52,10 +50,6 @@ export default function EditInvestmentModal({ isOpen, onClose, investment }: Edi
         pfCurrentAge: investment.pfCurrentAge || "",
         pfCompanyType: companyType,
         pfCompanyAmount: String(companyAmount || ""),
-        purchaseDate: investment.purchaseDate ? new Date(investment.purchaseDate).toISOString().split('T')[0] : "",
-        pfCurrentAge: investment.pfCurrentAge || "",
-        pfCurrentCompany: investment.pfCurrentCompany || investment.avgCost || "",
-        pfPreviousCompany: investment.pfPreviousCompany || investment.shares || "",
       });
     }
   }, [investment]);
@@ -72,11 +66,6 @@ export default function EditInvestmentModal({ isOpen, onClose, investment }: Edi
         pfPreviousCompany: isPf ? (isCurrentCompany ? "0" : data.pfCompanyAmount) : null,
       };
 
-      const payload = {
-        ...data,
-        pfCurrentCompany: data.type === "pf" ? data.avgCost : null,
-        pfPreviousCompany: data.type === "pf" ? data.shares : null,
-      };
       const response = await fetch(`http://localhost:8080/api/investments/${investment.id}`, {
         method: "PUT",
         headers: {
@@ -128,23 +117,6 @@ export default function EditInvestmentModal({ isOpen, onClose, investment }: Edi
             <div className="space-y-2">
               <Label htmlFor="name">Name</Label>
               <Input id="name" value={formData.name} onChange={(e) => handleInputChange("name", e.target.value)} required />
-              <Input
-                id="symbol"
-                value={formData.symbol}
-                onChange={(e) => handleInputChange("symbol", e.target.value)}
-                placeholder={isPfInvestment ? "UAN" : "AAPL"}
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="name">Name</Label>
-              <Input
-                id="name"
-                value={formData.name}
-                onChange={(e) => handleInputChange("name", e.target.value)}
-                placeholder={isPfInvestment ? "Employee Provident Fund" : "Apple Inc."}
-                required
-              />
             </div>
           </div>
 
@@ -217,69 +189,6 @@ export default function EditInvestmentModal({ isOpen, onClose, investment }: Edi
                 </div>
               </div>
             </>
-          )}
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="shares">{isPfInvestment ? "Previous Company PF Amount" : "Shares"}</Label>
-              <Input
-                id="shares"
-                type="number"
-                step="0.01"
-                value={formData.shares}
-                onChange={(e) => handleInputChange("shares", e.target.value)}
-                placeholder="0"
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="avgCost">{isPfInvestment ? "Current Company PF Amount" : "Average Cost"}</Label>
-              <div className="relative">
-              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{getCurrencySymbol()}</span>
-              <Input
-                id="avgCost"
-                type="number"
-                step="0.01"
-                value={formData.avgCost}
-                onChange={(e) => handleInputChange("avgCost", e.target.value)}
-                placeholder="150.00"
-                className="pl-8"
-                required
-              />
-            </div>
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="currentValue">{isPfInvestment ? "Current PF Balance" : "Current Value"}</Label>
-            <div className="relative">
-            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">{getCurrencySymbol()}</span>
-            <Input
-              id="currentValue"
-              type="number"
-              step="0.01"
-              value={formData.currentValue}
-              onChange={(e) => handleInputChange("currentValue", e.target.value)}
-              placeholder="1600.00"
-              className="pl-8"
-              required
-            />
-          </div>
-          </div>
-
-          {isPfInvestment && (
-            <div className="space-y-2">
-              <Label htmlFor="pfCurrentAge">Current Age</Label>
-              <Input
-                id="pfCurrentAge"
-                type="number"
-                min="18"
-                max="60"
-                value={formData.pfCurrentAge}
-                onChange={(e) => handleInputChange("pfCurrentAge", e.target.value)}
-                placeholder="32"
-                required
-              />
-            </div>
           )}
 
           <div className="space-y-2">


### PR DESCRIPTION
### Motivation
- Vite build was failing due to duplicated/malformed TypeScript/JSX fragments in the investment modal components, causing runtime 500 errors and a Babel error (`Identifier 'payload' has already been declared`).
- The PF (Provident Fund) payload mapping and form state were inconsistent because duplicate fields and controls were accidentally left in the files.

### Description
- Cleaned up `client/src/components/modals/add-investment-modal.tsx` by removing duplicated schema lines, duplicated mutation/payload fragments and extra duplicate JSX form controls, restoring a single valid Zod schema and submit flow.
- Fixed `client/src/components/modals/edit-investment-modal.tsx` by removing the duplicate `payload` declaration and removing duplicated state/JSX fragments so the update mapping is declared only once.
- Restored consistent PF mapping for submission so `pfCurrentCompany` / `pfPreviousCompany` are computed in a single `payload` object before sending to the API.

### Testing
- Ran the production build with `npm run -s build` and the build completed successfully (Vite compilation no longer fails).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863012cbe48333bc42d63a093f34c1)