### PR TITLE
Fix net worth projection compile errors in InsightsController

### DIFF
--- a/backend/src/main/java/com/fintrack/controller/InsightsController.java
+++ b/backend/src/main/java/com/fintrack/controller/InsightsController.java
@@ -233,8 +233,6 @@ public class InsightsController {
 
         double currentAssets = Math.max(0, monthlySavings) + totalInvestments;
         double currentDebts = Math.max(0, monthlyBills);
-        double currentAssets = currentSavings + totalInvestments;
-        double currentDebts = 0; // No debt tracking in current schema
 
         Map<String, Object> projection = new LinkedHashMap<>();
         projection.put("currentAssets", currentAssets);


### PR DESCRIPTION
### Motivation
- Duplicate declarations of `currentAssets` and `currentDebts` in `getNetWorthProjection` caused compile-time errors and referenced an undefined `currentSavings`, so the method needed to be corrected to use the intended computed values.

### Description
- Removed the duplicate declarations in `backend/src/main/java/com/fintrack/controller/InsightsController.java` so `currentAssets` is computed as `Math.max(0, monthlySavings) + totalInvestments` and `currentDebts` as `Math.max(0, monthlyBills)`.
- Left the projection map and subsequent calculations unchanged to continue using the corrected variables.

### Testing
- Ran `mvn -q -DskipTests compile` in the `backend` module, which failed due to a dependency resolution/network restriction (Maven Central returned HTTP 403), so full compilation validation could not complete.
- Attempted `./mvnw -q -DskipTests compile`, which failed because `mvnw` is not present in the repository, so no local wrapper execution was possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a0845053883339146fc16337b9875)