### PR TITLE
Auto-populate recurring bill next cycle for bills, dashboard, and insights

### DIFF
--- a/backend/src/main/java/com/fintrack/controller/BillController.java
+++ b/backend/src/main/java/com/fintrack/controller/BillController.java
@@ -2,6 +2,7 @@ package com.fintrack.controller;
 
 import com.fintrack.model.Bill;
 import com.fintrack.repository.BillRepository;
+import com.fintrack.util.RecurringBillService;
 import com.fintrack.util.UserUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -20,6 +21,9 @@ public class BillController {
     @Autowired
     private UserUtil userUtil;
 
+    @Autowired
+    private RecurringBillService recurringBillService;
+
     public BillController(BillRepository billRepository) {
         this.billRepository = billRepository;
     }
@@ -31,6 +35,7 @@ public class BillController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         System.out.println("Received GET /bills request for user: " + userId);
+        recurringBillService.autoPopulateNextCycleBills(userId);
         List<Bill> bills = billRepository.findByUserId(userId);
         System.out.println("Returning " + bills.size() + " bills");
         return ResponseEntity.ok(bills);
@@ -104,4 +109,5 @@ public class BillController {
                 })
                 .orElse(ResponseEntity.notFound().build());
     }
+
 }

--- a/backend/src/main/java/com/fintrack/controller/DashboardController.java
+++ b/backend/src/main/java/com/fintrack/controller/DashboardController.java
@@ -2,6 +2,7 @@ package com.fintrack.controller;
 
 import com.fintrack.model.*;
 import com.fintrack.repository.*;
+import com.fintrack.util.RecurringBillService;
 import com.fintrack.util.UserUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -23,6 +24,9 @@ public class DashboardController {
     @Autowired
     private UserUtil userUtil;
 
+    @Autowired
+    private RecurringBillService recurringBillService;
+
     public DashboardController(TransactionRepository transactionRepository,
                                BillRepository billRepository,
                                IncomeRepository incomeRepository,
@@ -39,6 +43,8 @@ public class DashboardController {
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
+
+        recurringBillService.autoPopulateNextCycleBills(userId);
 
         List<Transaction> transactions = transactionRepository.findByUserId(userId);
         List<Bill> bills = billRepository.findByUserId(userId);
@@ -158,6 +164,8 @@ public class DashboardController {
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
+
+        recurringBillService.autoPopulateNextCycleBills(userId);
 
         List<Transaction> transactions = transactionRepository.findByUserId(userId);
         List<Bill> bills = billRepository.findByUserId(userId);

--- a/backend/src/main/java/com/fintrack/controller/InsightsController.java
+++ b/backend/src/main/java/com/fintrack/controller/InsightsController.java
@@ -2,6 +2,7 @@ package com.fintrack.controller;
 
 import com.fintrack.model.*;
 import com.fintrack.repository.*;
+import com.fintrack.util.RecurringBillService;
 import com.fintrack.util.UserUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -22,6 +23,9 @@ public class InsightsController {
     @Autowired
     private UserUtil userUtil;
 
+    @Autowired
+    private RecurringBillService recurringBillService;
+
     public InsightsController(TransactionRepository transactionRepository,
                               BillRepository billRepository,
                               IncomeRepository incomeRepository,
@@ -38,6 +42,8 @@ public class InsightsController {
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
+
+        recurringBillService.autoPopulateNextCycleBills(userId);
 
         List<Transaction> transactions = transactionRepository.findByUserId(userId);
         List<Bill> bills = billRepository.findByUserId(userId);
@@ -100,6 +106,8 @@ public class InsightsController {
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
+
+        recurringBillService.autoPopulateNextCycleBills(userId);
 
         List<Transaction> transactions = transactionRepository.findByUserId(userId);
         List<Bill> bills = billRepository.findByUserId(userId);
@@ -204,6 +212,8 @@ public class InsightsController {
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
+
+        recurringBillService.autoPopulateNextCycleBills(userId);
 
         List<Transaction> transactions = transactionRepository.findByUserId(userId);
         List<Bill> bills = billRepository.findByUserId(userId);

--- a/backend/src/main/java/com/fintrack/util/RecurringBillService.java
+++ b/backend/src/main/java/com/fintrack/util/RecurringBillService.java
@@ -1,0 +1,74 @@
+package com.fintrack.util;
+
+import com.fintrack.model.Bill;
+import com.fintrack.repository.BillRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+public class RecurringBillService {
+    private final BillRepository billRepository;
+
+    public RecurringBillService(BillRepository billRepository) {
+        this.billRepository = billRepository;
+    }
+
+    public void autoPopulateNextCycleBills(Long userId) {
+        List<Bill> existingBills = billRepository.findByUserId(userId);
+
+        for (Bill sourceBill : existingBills) {
+            if (!Boolean.TRUE.equals(sourceBill.getIsRecurring())) {
+                continue;
+            }
+
+            LocalDate sourceDueDate = parseDueDate(sourceBill.getDueDate());
+            if (sourceDueDate == null) {
+                continue;
+            }
+
+            String nextDueDate = sourceDueDate.plusMonths(1).toString();
+            boolean alreadyExists = existingBills.stream().anyMatch(bill ->
+                    Objects.equals(bill.getName(), sourceBill.getName())
+                            && Objects.equals(bill.getCategory(), sourceBill.getCategory())
+                            && Objects.equals(bill.getAmount(), sourceBill.getAmount())
+                            && Objects.equals(bill.getDueDate(), nextDueDate)
+            );
+
+            if (alreadyExists) {
+                continue;
+            }
+
+            Bill nextCycleBill = new Bill();
+            nextCycleBill.setUserId(userId);
+            nextCycleBill.setName(sourceBill.getName());
+            nextCycleBill.setAmount(sourceBill.getAmount());
+            nextCycleBill.setCategory(sourceBill.getCategory());
+            nextCycleBill.setDueDate(nextDueDate);
+            nextCycleBill.setStatus(Boolean.TRUE.equals(sourceBill.getAutoPayEnabled()) ? "paid" : "pending");
+            nextCycleBill.setIsRecurring(true);
+            nextCycleBill.setAutoPayEnabled(sourceBill.getAutoPayEnabled());
+            nextCycleBill.setIcon(sourceBill.getIcon());
+            nextCycleBill.setColor(sourceBill.getColor());
+
+            Bill saved = billRepository.save(nextCycleBill);
+            existingBills.add(saved);
+        }
+    }
+
+    private LocalDate parseDueDate(String dueDate) {
+        if (dueDate == null || dueDate.isBlank()) {
+            return null;
+        }
+
+        try {
+            return LocalDate.parse(dueDate);
+        } catch (DateTimeParseException ex) {
+            System.out.println("Unable to parse bill due date: " + dueDate);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure the Bills & Utilities section, Dashboard, and Insights include upcoming recurring charges so projections and totals reflect the next billing cycle. 
- Support both recurring bills with and without auto-pay by auto-creating the next cycle entry and setting an appropriate default status so downstream calculations are consistent.

### Description
- Added a new backend service `RecurringBillService` (`backend/src/main/java/com/fintrack/util/RecurringBillService.java`) that generates the next-cycle bill for each recurring bill if a matching bill for that due date does not already exist. 
- Generated bills inherit `name`, `amount`, `category`, `icon`, `color`, and recurrence flags, and the generated bill `status` is set to `paid` when `autoPayEnabled` is true and `pending` when false. 
- Wired `recurringBillService.autoPopulateNextCycleBills(userId)` into `GET /api/bills` (`BillController`), `GET /api/dashboard` and `GET /api/dashboard/test` (`DashboardController`), and the Insights endpoints (`InsightsController`) so bills are auto-populated before controllers read bills for responses.

### Testing
- Attempted to compile the backend with `cd backend && mvn -q -DskipTests compile`, but the build could not complete because Maven failed to resolve the Spring Boot parent POM from Maven Central (HTTP 403), so automated compilation could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a135ab3688333a191e4826353b66e)